### PR TITLE
Changed String-widht from skypack's to esm.sh

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -3,7 +3,7 @@ export {
   assertEquals,
 } from "https://deno.land/std@0.65.0/testing/asserts.ts";
 export { sleep } from "https://deno.land/x/sleep@v1.2.1/mod.ts";
-import stringWidth from "https://cdn.skypack.dev/string-width@v5.1.2";
+import stringWidth from "https://esm.sh/string-width@5.1.2";
 export { stringWidth };
 export { Command } from "https://deno.land/x/cliffy@v0.19.2/command/mod.ts";
 export { parseFlags } from "https://deno.land/x/cliffy@v0.24.2/flags/mod.ts";


### PR DESCRIPTION
string-width の 提供元をcdn.skypack.dev のものからesm.sh のものに移行しました